### PR TITLE
Add NETTE_DEVEL enviroment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
 
     environment:
       - SSH_AUTH_SOCK=/ssh-agent
+      - NETTE_DEBUG=1
 
     volumes_from:
       - data


### PR DESCRIPTION
Debug mode can be now easily turned on in `app/bootstrap.php`.

```php
if (getenv('NETTE_DEVEL') === '1') {
    $configurator->setDebugMode(true);
}
```
For more details see [blog post (czech)](https://pehapkari.cz/blog/2017/01/23/inteligentni-debug-mode-v-nette/)
